### PR TITLE
Support dev: register

### DIFF
--- a/lib/unipi-input.html
+++ b/lib/unipi-input.html
@@ -70,8 +70,8 @@
             <option value="led">Led</option>
             <option value="temp">Temp</option>
             <option value="unit_register">Unit register</option>
+            <option value="register">Register</option>
             <option value="1wdevice">1-Wire Device</option>
-
         </select>
     </div>
     <div class="form-row">


### PR DESCRIPTION
3rdparty devices configured in Evok only support type REGISTER and then are accessible via websocket as `dev: "register"`. I am not sure if this was changed from "original" `unit_register` or if they are used for separate use-cases.

Example:
```
  {
    "value": 31100,
    "circuit": "UART_9_3_1_inp",
    "dev": "register",
    "glob_dev_id": 3
  },
  {
    "value": 17263,
    "circuit": "UART_9_3_0_inp",
    "dev": "register",
    "glob_dev_id": 3
  }
```